### PR TITLE
feat: use idiomatic Filecoin units for FIL formatting

### DIFF
--- a/metrics/src/utils/formatters.ts
+++ b/metrics/src/utils/formatters.ts
@@ -34,27 +34,36 @@ export function formatToken(
 export const formatFIL = (attoFil: string | bigint) => {
   if (!attoFil || attoFil === "0") return "0 FIL";
 
+  const value = BigInt(attoFil);
+  const filDivisor = BigInt(10) ** BigInt(18);
+  const filValue = value / filDivisor;
+  
+  // If >= 1 FIL, show as FIL with compact notation
+  if (filValue >= 1) {
+    return `${formatCompactNumber(filValue, 1)} FIL`;
+  }
+  
+  // For fractional FIL (>= 0.001 FIL), show with more decimals
+  const filValueWithDecimals = Number(value) / Number(filDivisor);
+  if (filValueWithDecimals >= 0.001) {
+    return `${filValueWithDecimals.toFixed(3)} FIL`;
+  }
+
+  // For smaller amounts, use appropriate smaller units
   const units = [
-    { name: "FIL", decimals: 18 },
-    { name: "milliFIL", decimals: 15 },
-    { name: "microFIL", decimals: 12 },
     { name: "nanoFIL", decimals: 9 },
     { name: "picoFIL", decimals: 6 },
     { name: "femtoFIL", decimals: 3 },
     { name: "attoFIL", decimals: 0 },
   ];
 
-  const value = BigInt(attoFil);
-
   for (const unit of units) {
     const divisor = BigInt(10) ** BigInt(unit.decimals);
     const unitValue = value / divisor;
 
     if (unitValue >= 1) {
-      const decimals = unit.name === "FIL" ? 1 : 2;
-      return unit.name === "FIL"
-        ? `${formatCompactNumber(unitValue, decimals)} FIL`
-        : `${unitValue.toString()} ${unit.name}`;
+      // Use compact formatting for smaller units
+      return `${formatCompactNumber(unitValue, 2)} ${unit.name}`;
     }
   }
 


### PR DESCRIPTION
Closes: #7 

### Summary

Updates FIL amount formatting to use idiomatic Filecoin units based on the [Lotus reference implementation](https://github.com/filecoin-project/lotus/blob/bdd9bb03b99688e289415da5571bddf48c82c1cf/chain/types/fil.go#L31-L34), and improves display logic for better readability across different value ranges.

Also improves the formatting logic with a three-tier approach:
- **>= 1 FIL**: Displays with compact notation (e.g., `1.2 K FIL`, `45.0 M FIL`)
- **0.001 - 1 FIL**: Shows fractional FIL with 3 decimals (e.g., `0.847 FIL`) instead of large nanoFIL numbers
- **< 0.001 FIL**: Uses appropriate smaller units with compact notation (e.g., `847.29 K nanoFIL`)

This prevents displaying confusing values like `847293000 nanoFIL` and instead shows the more readable `0.847 FIL`. The compact notation threshold is set at 1000 FIL, so values like `999 FIL` display as `999.0 FIL` while `1000 FIL` displays as `1.0 K FIL`.