### PR TITLE
feat: display countable metrics as integers

### DIFF
--- a/metrics/src/components/AnimatedCounter.tsx
+++ b/metrics/src/components/AnimatedCounter.tsx
@@ -31,8 +31,8 @@ export const AnimatedCounter: React.FC<AnimatedCounterProps> = ({
             setDisplayValue(value);
             clearInterval(counter);
           } else {
-            const formattedValue = startValue.toLocaleString(undefined, {
-              maximumFractionDigits: numericValue < 10 ? 2 : 0
+            const formattedValue = Math.floor(startValue).toLocaleString(undefined, {
+              maximumFractionDigits: 0
             });
             setDisplayValue(formattedValue + suffix);
           }

--- a/metrics/src/components/HeroStats.tsx
+++ b/metrics/src/components/HeroStats.tsx
@@ -6,7 +6,7 @@ import { AnimatedCounter } from "./AnimatedCounter";
 import { LoadingSpinner } from "./LoadingSpinner";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { usePaymentsMetrics } from "../hooks/useMetrics";
-import { formatFIL, formatCompactNumber } from "../utils/formatters";
+import { formatFIL, formatCountableMetric } from "../utils/formatters";
 
 export const HeroStats: React.FC = () => {
   const { data: paymentsMetric, isLoading, isError, error, refetch } = usePaymentsMetrics();
@@ -97,7 +97,7 @@ export const HeroStats: React.FC = () => {
         <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6'>
           <MetricCard
             title='Total Rails'
-            value={formatCompactNumber(paymentsMetric.totalRails)}
+            value={formatCountableMetric(paymentsMetric.totalRails)}
             subtitle='Payment channels created'
             changeType='positive'
             icon={Activity}
@@ -107,7 +107,7 @@ export const HeroStats: React.FC = () => {
 
           <MetricCard
             title='Active Rails'
-            value={formatCompactNumber(paymentsMetric.totalActiveRails)}
+            value={formatCountableMetric(paymentsMetric.totalActiveRails)}
             subtitle='Currently processing payments'
             changeType='positive'
             icon={TrendingUp}
@@ -117,7 +117,7 @@ export const HeroStats: React.FC = () => {
 
           <MetricCard
             title='Total Operators'
-            value={formatCompactNumber(paymentsMetric.totalOperators)}
+            value={formatCountableMetric(paymentsMetric.totalOperators)}
             subtitle='Network validators'
             changeType='positive'
             icon={Users}
@@ -127,7 +127,7 @@ export const HeroStats: React.FC = () => {
 
           <MetricCard
             title='Total Accounts'
-            value={formatCompactNumber(paymentsMetric.totalAccounts)}
+            value={formatCountableMetric(paymentsMetric.totalAccounts)}
             subtitle='Unique network participants'
             changeType='positive'
             icon={Coins}
@@ -140,7 +140,7 @@ export const HeroStats: React.FC = () => {
         <div className='grid grid-cols-1 md:grid-cols-3 gap-6 mt-6'>
           <MetricCard
             title='Unique Payers'
-            value={formatCompactNumber(paymentsMetric.uniquePayers)}
+            value={formatCountableMetric(paymentsMetric.uniquePayers)}
             subtitle='Active payment senders'
             icon={DollarSign}
             gradient='from-indigo-500 to-purple-600'
@@ -149,7 +149,7 @@ export const HeroStats: React.FC = () => {
 
           <MetricCard
             title='Unique Payees'
-            value={formatCompactNumber(paymentsMetric.uniquePayees)}
+            value={formatCountableMetric(paymentsMetric.uniquePayees)}
             subtitle='Payment recipients'
             icon={Users}
             gradient='from-cyan-500 to-blue-600'
@@ -158,7 +158,7 @@ export const HeroStats: React.FC = () => {
 
           <MetricCard
             title='Finalized Rails'
-            value={formatCompactNumber(paymentsMetric.totalFinalizedRails)}
+            value={formatCountableMetric(paymentsMetric.totalFinalizedRails)}
             subtitle='Successfully completed'
             changeType='positive'
             icon={Activity}

--- a/metrics/src/components/NetworkHealth.tsx
+++ b/metrics/src/components/NetworkHealth.tsx
@@ -4,7 +4,7 @@ import { Shield, Activity, Zap, CheckCircle } from "lucide-react";
 import { usePaymentsMetrics } from "../hooks/useMetrics";
 import { LoadingSpinner } from "./LoadingSpinner";
 import { ErrorBoundary } from "./ErrorBoundary";
-import { formatCompactNumber } from "../utils/formatters";
+import { formatCountableMetric } from "../utils/formatters";
 
 export const NetworkHealth: React.FC = () => {
   const { data: paymentsMetric, isLoading, isError, error, refetch } = usePaymentsMetrics();
@@ -78,7 +78,7 @@ export const NetworkHealth: React.FC = () => {
     {
       title: "Activity Level",
       value: "High",
-      description: `${formatCompactNumber(activeRails)} active`,
+      description: `${formatCountableMetric(activeRails)} active`,
       icon: Activity,
       color: "text-blue-400",
       bgColor: "from-blue-500",

--- a/metrics/src/components/OperatorLeaderboard.tsx
+++ b/metrics/src/components/OperatorLeaderboard.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { Activity, Crown, Users } from "lucide-react";
 import React from "react";
 import { useTopOperatorTokens } from "../hooks/useMetrics";
-import { formatAddress, formatCompactNumber, formatToken } from "../utils/formatters";
+import { formatAddress, formatCountableMetric, formatToken } from "../utils/formatters";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { LoadingSpinner } from "./LoadingSpinner";
 
@@ -125,14 +125,14 @@ export const OperatorLeaderboard: React.FC = () => {
                     <div>
                       <div className='flex items-center gap-1 text-green-400'>
                         <Activity className='w-3 h-3' />
-                        <span>{formatCompactNumber(operator.operator.totalRails)}</span>
+                        <span>{formatCountableMetric(operator.operator.totalRails)}</span>
                       </div>
                       <p className='text-gray-400 text-xs'>Rails</p>
                     </div>
                     <div>
                       <div className='flex items-center gap-1 text-blue-400'>
                         <Users className='w-3 h-3' />
-                        <span>{formatCompactNumber(operator.operator.totalApprovals)}</span>
+                        <span>{formatCountableMetric(operator.operator.totalApprovals)}</span>
                       </div>
                       <p className='text-gray-400 text-xs'>Approvals</p>
                     </div>

--- a/metrics/src/components/TopOperatorCharts.tsx
+++ b/metrics/src/components/TopOperatorCharts.tsx
@@ -74,7 +74,7 @@ export const TopOperatorCharts: React.FC = () => {
               <div key={index} className='flex items-center gap-2'>
                 <div className='w-3 h-3 rounded-full' style={{ backgroundColor: entry.color }} />
                 <span className='text-white text-sm'>
-                  {operator} {metricName}: {entry.value.toLocaleString()}
+                  {operator} {metricName}: {Math.round(entry.value).toLocaleString()}
                 </span>
               </div>
             );

--- a/metrics/src/components/TrendChart.tsx
+++ b/metrics/src/components/TrendChart.tsx
@@ -78,7 +78,7 @@ export const TrendChart: React.FC = () => {
               <div className='w-3 h-3 rounded-full' style={{ backgroundColor: entry.color }} />
               <span className='text-white text-sm'>
                 {entry.name}:{" "}
-                {entry.name === "FIL Burned" ? formatFIL(BigInt(entry.value)) : entry.value.toLocaleString()}
+                {entry.name === "FIL Burned" ? formatFIL(BigInt(entry.value)) : Math.round(entry.value).toLocaleString()}
               </span>
             </div>
           ))}

--- a/metrics/src/utils/formatters.ts
+++ b/metrics/src/utils/formatters.ts
@@ -20,6 +20,10 @@ export function formatCompactNumber(value: number | string | bigint, decimals: n
   return `${(value / Math.pow(1000, i)).toFixed(decimals).replace(/\.?0+$/, "")} ${sizes[i]}`;
 }
 
+export function formatCountableMetric(value: number | string | bigint) {
+  return formatCompactNumber(value, 0);
+}
+
 export function formatToken(
   value: number | string | bigint,
   tokenDecimals: number | bigint = 18,


### PR DESCRIPTION
Closes: #11 

Update all countable metrics (rails, operators, accounts, approvals, etc.) to display as whole numbers instead of with decimal places. Token amounts and other continuous metrics still display with appropriate precision.