### PR TITLE
fix(explorer): temporarily hide network revenue stat

### DIFF
--- a/apps/explorer/src/components/Home/Stats.tsx
+++ b/apps/explorer/src/components/Home/Stats.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo } from "react";
 import { getChain } from "@/constants/chains";
 import usePayMetrics from "@/hooks/usePayMetrics";
 import { useTokenDetails } from "@/hooks/useTokenDetails";
-import { formatCompactNumber, formatFIL, formatToken } from "@/utils/formatter";
+import { formatCompactNumber, formatToken } from "@/utils/formatter";
 import { MetricItem } from "../shared";
 
 interface StatsLayoutProps {
@@ -115,12 +115,14 @@ const Stats: React.FC = () => {
         icon: "/stats/total-services.svg",
         tooltip: "Payment managers that help automate transactions between users",
       },
-      {
-        title: "Network Revenue",
-        value: formatFIL(data?.totalFilBurned || "0"),
-        icon: "/stats/total-fil-burned.svg",
-        tooltip: "Network fees paid to process payment settlements",
-      },
+      // TODO: Add this back when network revenue calculation is fixed
+      // See https://github.com/FilOzone/filecoin-pay-explorer/issues/70
+      // {
+      //   title: "Network Revenue",
+      //   value: formatFIL(data?.totalFilBurned || "0"),
+      //   icon: "/stats/total-fil-burned.svg",
+      //   tooltip: "Network fees paid to process payment settlements",
+      // },
       {
         title: "USDFC Settled",
         value: usdfcData

--- a/apps/explorer/src/components/Rail/RailSettlements.tsx
+++ b/apps/explorer/src/components/Rail/RailSettlements.tsx
@@ -95,7 +95,7 @@ export const RailSettlements: React.FC<RailSettlementsProps> = ({ rail }) => {
               <TableHead>Settled Upto</TableHead>
               <TableHead className='text-right'>Total Settled</TableHead>
               <TableHead className='text-right'>Net Payee Amount</TableHead>
-              <TableHead className='text-right'>Network Revenue</TableHead>
+              <TableHead className='text-right'>Network Fees</TableHead>
               <TableHead className='text-right'>Operator Commission</TableHead>
             </TableRow>
           </TableHeader>


### PR DESCRIPTION
Temporarily hide network revenue stat which is misleading at the moment. See https://github.com/FilOzone/filecoin-pay-explorer/issues/70 for more details.