### PR TITLE
fix: show one-time rail payment amounts and label

### DIFF
--- a/apps/explorer/src/components/Home/RecentRails/data/column-definitions.tsx
+++ b/apps/explorer/src/components/Home/RecentRails/data/column-definitions.tsx
@@ -43,10 +43,20 @@ export const columns = [
       );
     },
   }),
-  columnHelper.accessor("state", {
-    header: "State",
-    cell: (info) => <RailStateBadge state={info.getValue()} />,
-  }),
+  columnHelper.accessor(
+    (row) => ({
+      state: row.state,
+      isOtp: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
+    }),
+    {
+      id: "state",
+      header: "State",
+      cell: (info) => {
+        const { state, isOtp } = info.getValue();
+        return <RailStateBadge state={state} isOneTimePayment={isOtp} />;
+      },
+    },
+  ),
   columnHelper.accessor(
     (row) => ({
       paymentRate: row.paymentRate,
@@ -64,14 +74,16 @@ export const columns = [
   columnHelper.accessor(
     (row) => ({
       totalSettledAmount: row.totalSettledAmount,
+      totalOneTimePaymentAmount: row.totalOneTimePaymentAmount,
       token: row.token,
     }),
     {
-      id: "settledAmount",
-      header: "Settled Amount",
+      id: "transactedAmount",
+      header: "Transacted Amount",
       cell: (info) => {
-        const { totalSettledAmount, token } = info.getValue();
-        return formatToken(totalSettledAmount, token.decimals, token.symbol, 8);
+        const { totalSettledAmount, totalOneTimePaymentAmount, token } = info.getValue();
+        const total = BigInt(totalSettledAmount) + BigInt(totalOneTimePaymentAmount ?? 0);
+        return formatToken(total, token.decimals, token.symbol, 8);
       },
     },
   ),

--- a/apps/explorer/src/components/Home/RecentRails/data/column-definitions.tsx
+++ b/apps/explorer/src/components/Home/RecentRails/data/column-definitions.tsx
@@ -46,14 +46,14 @@ export const columns = [
   columnHelper.accessor(
     (row) => ({
       state: row.state,
-      isOtp: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
+      isOneTimePayment: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
     }),
     {
       id: "state",
       header: "State",
       cell: (info) => {
-        const { state, isOtp } = info.getValue();
-        return <RailStateBadge state={state} isOneTimePayment={isOtp} />;
+        const { state, isOneTimePayment } = info.getValue();
+        return <RailStateBadge state={state} isOneTimePayment={isOneTimePayment} />;
       },
     },
   ),

--- a/apps/explorer/src/components/Rails/data/column-definitions.tsx
+++ b/apps/explorer/src/components/Rails/data/column-definitions.tsx
@@ -64,10 +64,20 @@ export const columns = [
       );
     },
   }),
-  columnHelper.accessor("state", {
-    header: "Status",
-    cell: (info) => <RailStateBadge state={info.getValue()} />,
-  }),
+  columnHelper.accessor(
+    (row) => ({
+      state: row.state,
+      isOtp: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
+    }),
+    {
+      id: "state",
+      header: "Status",
+      cell: (info) => {
+        const { state, isOtp } = info.getValue();
+        return <RailStateBadge state={state} isOneTimePayment={isOtp} />;
+      },
+    },
+  ),
   columnHelper.accessor(
     (row) => ({
       paymentRate: row.paymentRate,

--- a/apps/explorer/src/components/Rails/data/column-definitions.tsx
+++ b/apps/explorer/src/components/Rails/data/column-definitions.tsx
@@ -67,14 +67,14 @@ export const columns = [
   columnHelper.accessor(
     (row) => ({
       state: row.state,
-      isOtp: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
+      isOneTimePayment: BigInt(row.paymentRate) === 0n && BigInt(row.totalOneTimePaymentAmount ?? 0) > 0n,
     }),
     {
       id: "state",
       header: "Status",
       cell: (info) => {
-        const { state, isOtp } = info.getValue();
-        return <RailStateBadge state={state} isOneTimePayment={isOtp} />;
+        const { state, isOneTimePayment } = info.getValue();
+        return <RailStateBadge state={state} isOneTimePayment={isOneTimePayment} />;
       },
     },
   ),

--- a/apps/explorer/src/components/shared/RailStateBadge.tsx
+++ b/apps/explorer/src/components/shared/RailStateBadge.tsx
@@ -13,7 +13,9 @@ interface RailStateBadgeProps {
   className?: string;
 }
 
-const RAIL_STATE_CONFIG: Record<string, StateConfig> = {
+type StateKey = Exclude<RailState, "%future added value"> | "ONE_TIME_PAYMENT";
+
+const RAIL_STATE_CONFIG: Record<StateKey, StateConfig> = {
   ACTIVE: {
     label: "Active",
     dotColor: "bg-brand-300",

--- a/apps/explorer/src/components/shared/RailStateBadge.tsx
+++ b/apps/explorer/src/components/shared/RailStateBadge.tsx
@@ -1,12 +1,19 @@
 import type { RailState } from "@filecoin-pay/types";
 import { cn } from "@filecoin-pay/ui/lib/utils";
 
+interface StateConfig {
+  label: string;
+  dotColor: string;
+  textColor: string;
+}
+
 interface RailStateBadgeProps {
   state: RailState;
+  isOneTimePayment?: boolean;
   className?: string;
 }
 
-const RAIL_STATE_CONFIG = {
+const RAIL_STATE_CONFIG: Record<string, StateConfig> = {
   ACTIVE: {
     label: "Active",
     dotColor: "bg-brand-300",
@@ -27,10 +34,22 @@ const RAIL_STATE_CONFIG = {
     dotColor: "bg-gray-500",
     textColor: "text-slate-800 dark:text-slate-200",
   },
-} as const;
+  ONE_TIME_PAYMENT: {
+    label: "One-Time Payment",
+    dotColor: "bg-blue-500",
+    textColor: "text-slate-800 dark:text-slate-200",
+  },
+};
 
-export function RailStateBadge({ state, className }: RailStateBadgeProps) {
-  const config = state === "%future added value" ? RAIL_STATE_CONFIG.ZERORATE : RAIL_STATE_CONFIG[state];
+export function RailStateBadge({ state, isOneTimePayment, className }: RailStateBadgeProps) {
+  let config: StateConfig;
+  if (isOneTimePayment) {
+    config = RAIL_STATE_CONFIG.ONE_TIME_PAYMENT;
+  } else if (state === "%future added value") {
+    config = RAIL_STATE_CONFIG.ZERORATE;
+  } else {
+    config = RAIL_STATE_CONFIG[state];
+  }
 
   return (
     <div className={cn("inline-flex items-center gap-2.5", className)}>

--- a/apps/explorer/src/components/shared/RailStateBadge.tsx
+++ b/apps/explorer/src/components/shared/RailStateBadge.tsx
@@ -44,14 +44,15 @@ const RAIL_STATE_CONFIG: Record<StateKey, StateConfig> = {
 };
 
 export function RailStateBadge({ state, isOneTimePayment, className }: RailStateBadgeProps) {
-  let config: StateConfig;
-  if (isOneTimePayment) {
-    config = RAIL_STATE_CONFIG.ONE_TIME_PAYMENT;
-  } else if (state === "%future added value") {
-    config = RAIL_STATE_CONFIG.ZERORATE;
-  } else {
-    config = RAIL_STATE_CONFIG[state];
-  }
+  // Use the underlying state for lifecycle (Active/Terminated/Finalized),
+  // but add a one-time payment indicator when applicable
+  const stateConfig = state === "%future added value" ? RAIL_STATE_CONFIG.ZERORATE : RAIL_STATE_CONFIG[state];
+
+  // For active/idle one-time payment rails, use the blue badge.
+  // For terminated/finalized, keep the lifecycle state but append the type.
+  const isTerminalState = state === "TERMINATED" || state === "FINALIZED";
+  const config = isOneTimePayment && !isTerminalState ? RAIL_STATE_CONFIG.ONE_TIME_PAYMENT : stateConfig;
+  const label = isOneTimePayment && isTerminalState ? `${config.label} (One-Time)` : config.label;
 
   return (
     <div className={cn("inline-flex items-center gap-2.5", className)}>
@@ -61,7 +62,7 @@ export function RailStateBadge({ state, isOneTimePayment, className }: RailState
         {/* Inner dot */}
         <div className={cn("relative w-3 h-3 rounded-full", config.dotColor)} />
       </div>
-      <span className={cn("font-medium text-lg", config.textColor)}>{config.label}</span>
+      <span className={cn("font-medium text-lg", config.textColor)}>{label}</span>
     </div>
   );
 }

--- a/apps/explorer/src/services/grapql/queries.ts
+++ b/apps/explorer/src/services/grapql/queries.ts
@@ -76,6 +76,7 @@ export const GET_RECENT_RAILS = gql`
       state
       paymentRate
       totalSettledAmount
+      totalOneTimePaymentAmount
       createdAt
       payer {
         address


### PR DESCRIPTION
Ref: https://filecoinproject.slack.com/archives/C07CGTXHHT4/p1774388249074779

They're currently showing as "Settled" for "0".