### PR TITLE
feat(Rail.Stats): Render days instead of epochs

### DIFF
--- a/apps/explorer/src/components/Rail/components/Stats.tsx
+++ b/apps/explorer/src/components/Rail/components/Stats.tsx
@@ -164,7 +164,7 @@ export const Stats: React.FC<StatsProps> = ({ rail }) => {
               {BigInt(rail.paymentRate) > 0n && BigInt(rail.lockupPeriod) > 0n && (
                 <MetricItem
                   title='Lockup Period'
-                  value={`${((Number(rail.lockupPeriod) * EPOCH_DURATION) / 60) / 60 / 24} days`}
+                  value={`${Math.ceil((Number(rail.lockupPeriod) * EPOCH_DURATION) / 60 / 60 / 24)} days`}
                   tooltip={`${Number(rail.lockupPeriod)} epochs`}
                   Icon={HourglassIcon}
                 />

--- a/apps/explorer/src/components/Rail/components/Stats.tsx
+++ b/apps/explorer/src/components/Rail/components/Stats.tsx
@@ -23,6 +23,7 @@ import {
 import { AlertCircle } from "lucide-react";
 import { useMemo } from "react";
 import { useBlockNumber } from "@/hooks/useBlockNumber";
+import { EPOCH_DURATION } from "@/utils/constants";
 import { epochToDate, formatToken } from "@/utils/formatter";
 import { CopyableText, MetricItem, RailStateBadge } from "../../shared";
 
@@ -140,7 +141,7 @@ export const Stats: React.FC<StatsProps> = ({ rail }) => {
               <MetricItem
                 title='Payment Rate'
                 value={formatToken(
-                  Number(rail.paymentRate) * 2 * 60 * 24,
+                  (Number(rail.paymentRate) / EPOCH_DURATION) * 60 * 60 * 24,
                   rail.token.decimals,
                   `${rail.token.symbol}/day`,
                   12,

--- a/apps/explorer/src/components/Rail/components/Stats.tsx
+++ b/apps/explorer/src/components/Rail/components/Stats.tsx
@@ -254,7 +254,6 @@ export const Stats: React.FC<StatsProps> = ({ rail }) => {
               day: "numeric",
               year: "numeric",
             })}
-            tooltip={`Epoch ${rail.createdAt}`}
             Icon={CalendarPlusIcon}
           />
           {Number(rail.endEpoch) > 0 && !isOneTimePaymentOnly && (

--- a/apps/explorer/src/components/Rail/components/Stats.tsx
+++ b/apps/explorer/src/components/Rail/components/Stats.tsx
@@ -164,7 +164,7 @@ export const Stats: React.FC<StatsProps> = ({ rail }) => {
               {BigInt(rail.paymentRate) > 0n && BigInt(rail.lockupPeriod) > 0n && (
                 <MetricItem
                   title='Lockup Period'
-                  value={`${Number(rail.lockupPeriod) / 2 / 60 / 24} days`}
+                  value={`${((Number(rail.lockupPeriod) * EPOCH_DURATION) / 60) / 60 / 24} days`}
                   tooltip={`${Number(rail.lockupPeriod)} epochs`}
                   Icon={HourglassIcon}
                 />

--- a/apps/explorer/src/components/Rail/components/Stats.tsx
+++ b/apps/explorer/src/components/Rail/components/Stats.tsx
@@ -1,3 +1,6 @@
+import { Button } from "@filecoin-foundation/ui-filecoin/Button";
+import { EmptyStateCard } from "@filecoin-foundation/ui-filecoin/EmptyStateCard";
+import { LoadingStateCard } from "@filecoin-foundation/ui-filecoin/LoadingStateCard";
 import { PageSection } from "@filecoin-foundation/ui-filecoin/PageSection";
 import type { Rail, RailState } from "@filecoin-pay/types";
 import {
@@ -17,8 +20,10 @@ import {
   UserGearIcon,
   WalletIcon,
 } from "@phosphor-icons/react";
+import { AlertCircle } from "lucide-react";
 import { useMemo } from "react";
-import { formatToken } from "@/utils/formatter";
+import { useBlockNumber } from "@/hooks/useBlockNumber";
+import { epochToDate, formatToken } from "@/utils/formatter";
 import { CopyableText, MetricItem, RailStateBadge } from "../../shared";
 
 interface StatsLayoutProps {
@@ -39,6 +44,24 @@ const StatsLayout: React.FC<StatsLayoutProps> = ({ children, railId, state }) =>
   </PageSection>
 );
 
+interface ErrorStateProps {
+  refetch: () => void;
+  error: Error | null;
+}
+
+const ErrorState: React.FC<ErrorStateProps> = ({ refetch, error }) => (
+  <EmptyStateCard
+    icon={AlertCircle}
+    title='Failed to load stats'
+    titleTag='h2'
+    description={error?.message || "Something went wrong"}
+  >
+    <Button onClick={refetch} variant='primary' size='compact'>
+      Retry
+    </Button>
+  </EmptyStateCard>
+);
+
 interface StatsProps {
   rail: Rail;
 }
@@ -57,155 +80,197 @@ export const Stats: React.FC<StatsProps> = ({ rail }) => {
     BigInt(rail.lockupFixed) === 0n &&
     BigInt(rail.lockupPeriod) === 0n &&
     rail.arbiter === "0x0000000000000000000000000000000000000000";
+  const { data: currentBlock, isLoading, isError, refetch, error } = useBlockNumber();
 
   return (
     <StatsLayout railId={String(rail.railId)} state={rail.state}>
-      <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'>
-        <MetricItem
-          title='Payer'
-          value={
-            <CopyableText
-              value={rail.payer.address}
-              // to={`/account/${rail.payer.address}`}
-              monospace={true}
-              label='Payer address'
-              truncate={true}
-              truncateLength={8}
-            />
-          }
-          Icon={HandDepositIcon}
-        />
-        <MetricItem
-          title='Payee'
-          value={
-            <CopyableText
-              value={rail.payee.address}
-              // to={`/account/${rail.payee.address}`}
-              monospace={true}
-              label='Payee address'
-              truncate={true}
-              truncateLength={8}
-            />
-          }
-          Icon={HandWithdrawIcon}
-        />
-        <MetricItem
-          title='Operator'
-          value={
-            <CopyableText
-              value={rail.operator.address}
-              // to={`/account/${rail.operator.address}`}
-              monospace={true}
-              label='Operator address'
-              truncate={true}
-              truncateLength={8}
-            />
-          }
-          Icon={UserGearIcon}
-        />
+      {isLoading && <LoadingStateCard message='Loading Stats...' />}
 
-        <MetricItem title='Token' value={rail.token.symbol} Icon={CoinsIcon} />
+      {isError && <ErrorState refetch={refetch} error={error} />}
 
-        {!isOneTimePaymentOnly && (
-          <>
-            <MetricItem
-              title='Payment Rate'
-              value={formatToken(rail.paymentRate, rail.token.decimals, `${rail.token.symbol}/epoch`, 12)}
-              Icon={TrendUpIcon}
-            />
-            {BigInt(rail.lockupFixed) > 0n && (
-              <MetricItem
-                title='Lockup Fixed'
-                value={formatToken(rail.lockupFixed, rail.token.decimals, rail.token.symbol, 2)}
-                Icon={LockIcon}
-              />
-            )}
-            {BigInt(rail.paymentRate) > 0n && BigInt(rail.lockupPeriod) > 0n && (
-              <MetricItem title='Lockup Period' value={`${rail.lockupPeriod.toString()} epochs`} Icon={HourglassIcon} />
-            )}
-          </>
-        )}
-
-        {Number(rail.totalSettlements) > 0 && (
-          <>
-            <MetricItem title='Settled Upto' value={`Epoch ${rail.settledUpto.toString()}`} Icon={CalendarCheckIcon} />
-            <MetricItem
-              title='Total Settled Amount'
-              value={formatToken(rail.totalSettledAmount, rail.token.decimals, rail.token.symbol, 8)}
-              Icon={CheckCircleIcon}
-            />
-          </>
-        )}
-
-        {Number(rail.totalOneTimePayments) > 0 && (
+      {!isLoading && !isError && currentBlock && (
+        <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'>
           <MetricItem
-            title='Paid One Time'
-            value={formatToken(rail.totalOneTimePaymentAmount, rail.token.decimals, rail.token.symbol, 8)}
-            Icon={CheckCircleIcon}
-          />
-        )}
-        <MetricItem
-          title='Total Net Payee Amount'
-          value={formatToken(totalNetPayeeAmount, rail.token.decimals, rail.token.symbol, 8)}
-          Icon={WalletIcon}
-        />
-        <MetricItem
-          title='Total Commission'
-          value={formatToken(totalCommission, rail.token.decimals, rail.token.symbol, 8)}
-          Icon={TagIcon}
-        />
-
-        {Number(rail.commissionRateBps) > 0 && (
-          <>
-            <MetricItem
-              title='Commission Rate'
-              value={`${(Number(rail.commissionRateBps) / 100).toFixed(2)}%`}
-              Icon={TagIcon}
-            />
-            <MetricItem
-              title='Service Fee Recipient'
-              value={
-                <CopyableText
-                  value={rail.serviceFeeRecipient}
-                  monospace={true}
-                  label='Service Fee Recipient address'
-                  truncate={true}
-                  truncateLength={8}
-                />
-              }
-              Icon={ReceiptIcon}
-            />
-          </>
-        )}
-
-        {!isOneTimePaymentOnly && (
-          <MetricItem
-            title='Arbiter'
+            title='Payer'
             value={
               <CopyableText
-                value={rail.arbiter}
+                value={rail.payer.address}
+                // to={`/account/${rail.payer.address}`}
                 monospace={true}
-                label='Arbiter address'
+                label='Payer address'
                 truncate={true}
                 truncateLength={8}
               />
             }
-            Icon={GavelIcon}
+            Icon={HandDepositIcon}
           />
-        )}
-        <MetricItem
-          title='Created At'
-          value={new Date(Number(rail.createdAt) * 1000).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-            year: "numeric",
-          })}
-          Icon={CalendarPlusIcon}
-        />
-        {Number(rail.endEpoch) > 0 && !isOneTimePaymentOnly && (
-          <MetricItem title='End' value={`Epoch ${rail.endEpoch}`} Icon={CalendarSlashIcon} />
-        )}
-      </div>
+          <MetricItem
+            title='Payee'
+            value={
+              <CopyableText
+                value={rail.payee.address}
+                // to={`/account/${rail.payee.address}`}
+                monospace={true}
+                label='Payee address'
+                truncate={true}
+                truncateLength={8}
+              />
+            }
+            Icon={HandWithdrawIcon}
+          />
+          <MetricItem
+            title='Operator'
+            value={
+              <CopyableText
+                value={rail.operator.address}
+                // to={`/account/${rail.operator.address}`}
+                monospace={true}
+                label='Operator address'
+                truncate={true}
+                truncateLength={8}
+              />
+            }
+            Icon={UserGearIcon}
+          />
+
+          <MetricItem title='Token' value={rail.token.symbol} Icon={CoinsIcon} />
+
+          {!isOneTimePaymentOnly && (
+            <>
+              <MetricItem
+                title='Payment Rate'
+                value={formatToken(
+                  Number(rail.paymentRate) * 2 * 60 * 24,
+                  rail.token.decimals,
+                  `${rail.token.symbol}/day`,
+                  12,
+                )}
+                tooltip={`${formatToken(
+                  Number(rail.paymentRate),
+                  rail.token.decimals,
+                  `${rail.token.symbol}`,
+                  12,
+                )}/epoch`}
+                Icon={TrendUpIcon}
+              />
+              {BigInt(rail.lockupFixed) > 0n && (
+                <MetricItem
+                  title='Lockup Fixed'
+                  value={formatToken(rail.lockupFixed, rail.token.decimals, rail.token.symbol, 2)}
+                  Icon={LockIcon}
+                />
+              )}
+              {BigInt(rail.paymentRate) > 0n && BigInt(rail.lockupPeriod) > 0n && (
+                <MetricItem
+                  title='Lockup Period'
+                  value={`${Number(rail.lockupPeriod) / 2 / 60 / 24} days`}
+                  tooltip={`${Number(rail.lockupPeriod)} epochs`}
+                  Icon={HourglassIcon}
+                />
+              )}
+            </>
+          )}
+
+          {Number(rail.totalSettlements) > 0 && (
+            <>
+              <MetricItem
+                title='Settled Upto'
+                value={epochToDate(rail.settledUpto, currentBlock).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+                tooltip={`Epoch ${rail.settledUpto}`}
+                Icon={CalendarCheckIcon}
+              />
+              <MetricItem
+                title='Total Settled Amount'
+                value={formatToken(rail.totalSettledAmount, rail.token.decimals, rail.token.symbol, 8)}
+                Icon={CheckCircleIcon}
+              />
+            </>
+          )}
+
+          {Number(rail.totalOneTimePayments) > 0 && (
+            <MetricItem
+              title='Paid One Time'
+              value={formatToken(rail.totalOneTimePaymentAmount, rail.token.decimals, rail.token.symbol, 8)}
+              Icon={CheckCircleIcon}
+            />
+          )}
+          <MetricItem
+            title='Total Net Payee Amount'
+            value={formatToken(totalNetPayeeAmount, rail.token.decimals, rail.token.symbol, 8)}
+            Icon={WalletIcon}
+          />
+          <MetricItem
+            title='Total Commission'
+            value={formatToken(totalCommission, rail.token.decimals, rail.token.symbol, 8)}
+            Icon={TagIcon}
+          />
+
+          {Number(rail.commissionRateBps) > 0 && (
+            <>
+              <MetricItem
+                title='Commission Rate'
+                value={`${(Number(rail.commissionRateBps) / 100).toFixed(2)}%`}
+                Icon={TagIcon}
+              />
+              <MetricItem
+                title='Service Fee Recipient'
+                value={
+                  <CopyableText
+                    value={rail.serviceFeeRecipient}
+                    monospace={true}
+                    label='Service Fee Recipient address'
+                    truncate={true}
+                    truncateLength={8}
+                  />
+                }
+                Icon={ReceiptIcon}
+              />
+            </>
+          )}
+
+          {!isOneTimePaymentOnly && (
+            <MetricItem
+              title='Arbiter'
+              value={
+                <CopyableText
+                  value={rail.arbiter}
+                  monospace={true}
+                  label='Arbiter address'
+                  truncate={true}
+                  truncateLength={8}
+                />
+              }
+              Icon={GavelIcon}
+            />
+          )}
+          <MetricItem
+            title='Created At'
+            value={new Date(Number(rail.createdAt) * 1000).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
+            tooltip={`Epoch ${rail.createdAt}`}
+            Icon={CalendarPlusIcon}
+          />
+          {Number(rail.endEpoch) > 0 && !isOneTimePaymentOnly && (
+            <MetricItem
+              title='Ends At'
+              value={epochToDate(rail.endEpoch, currentBlock).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+              tooltip={`Epoch ${rail.endEpoch}`}
+              Icon={CalendarSlashIcon}
+            />
+          )}
+        </div>
+      )}
     </StatsLayout>
   );
 };


### PR DESCRIPTION
After:

<img width="1395" height="655" alt="Screenshot 2026-05-04 at 10 01 39" src="https://github.com/user-attachments/assets/142c6b6f-fdb9-48ac-9e8b-5ece1054630f" />

Before:

<img width="1397" height="651" alt="Screenshot 2026-05-04 at 10 01 58" src="https://github.com/user-attachments/assets/9244c8ef-a880-4e30-a522-55a697339d12" />

Requested in https://filecoinproject.slack.com/archives/C07CGTXHHT4/p1777563230889249?thread_ts=1777553102.292809&cid=C07CGTXHHT4

Raw epochs are shown in tooltips