### PR TITLE
fix(subgraph): rename `arbiter` to `validator`

### DIFF
--- a/packages/subgraph/schemas/schema.v1.graphql
+++ b/packages/subgraph/schemas/schema.v1.graphql
@@ -100,7 +100,8 @@ type Rail @entity(immutable: false) {
   settledUpto: BigInt!
   state: RailState!
   endEpoch: BigInt!
-  arbiter: Bytes!
+  validator: Bytes!
+  arbiter: Bytes! # legacy
   commissionRateBps: BigInt!
   serviceFeeRecipient: Bytes!
 

--- a/packages/subgraph/src/payments.ts
+++ b/packages/subgraph/src/payments.ts
@@ -128,7 +128,7 @@ export function handleRailCreated(event: RailCreatedEvent): void {
   const railId = event.params.railId;
   const payeeAddress = event.params.payee;
   const payerAddress = event.params.payer;
-  const arbiter = event.params.validator;
+  const validator = event.params.validator;
   const tokenAddress = event.params.token;
   const operatorAddress = event.params.operator;
   const commissionRateBps = event.params.commissionRateBps;
@@ -157,7 +157,7 @@ export function handleRailCreated(event: RailCreatedEvent): void {
     payeeAddress,
     operatorAddress,
     tokenAddress,
-    arbiter,
+    validator,
     event.block.number,
     commissionRateBps,
     serviceFeeRecipient,

--- a/packages/subgraph/src/utils/helpers.ts
+++ b/packages/subgraph/src/utils/helpers.ts
@@ -228,7 +228,7 @@ export const createRail = (
   payee: Address,
   operator: Address,
   token: Address,
-  arbiter: Address,
+  validator: Address,
   settledUpTo: GraphBN,
   commissionRateBps: GraphBN,
   serviceFeeRecipient: Address,
@@ -248,7 +248,8 @@ export const createRail = (
   rail.settledUpto = settledUpTo;
   rail.state = "ZERORATE";
   rail.endEpoch = ZERO_BIG_INT;
-  rail.arbiter = arbiter;
+  rail.validator = validator;
+  rail.arbiter = validator; // legacy
   rail.totalSettledAmount = ZERO_BIG_INT;
   rail.totalOneTimePaymentAmount = ZERO_BIG_INT;
   rail.totalOneTimePayments = ZERO_BIG_INT;

--- a/packages/subgraph/tests/payments/fixtures.ts
+++ b/packages/subgraph/tests/payments/fixtures.ts
@@ -216,7 +216,7 @@ export function assertRailParams(
   state: string,
   payer: Address,
   payee: Address,
-  arbiter: Address,
+  validator: Address,
   serviceFeeRecipient: Address,
   commissionRateBps: GraphBN,
   totalSettledAmount: string,
@@ -228,7 +228,7 @@ export function assertRailParams(
   assert.fieldEquals("Rail", railEntityId, "state", state);
   assert.fieldEquals("Rail", railEntityId, "payer", payer.toHex());
   assert.fieldEquals("Rail", railEntityId, "payee", payee.toHex());
-  assert.fieldEquals("Rail", railEntityId, "arbiter", arbiter.toHex());
+  assert.fieldEquals("Rail", railEntityId, "validator", validator.toHex());
   assert.fieldEquals("Rail", railEntityId, "serviceFeeRecipient", serviceFeeRecipient.toHex());
   assert.fieldEquals("Rail", railEntityId, "commissionRateBps", commissionRateBps.toString());
   assert.fieldEquals("Rail", railEntityId, "totalOneTimePaymentAmount", totalOneTimePaymentAmount);

--- a/packages/subgraph/tests/payments/fixtures.ts
+++ b/packages/subgraph/tests/payments/fixtures.ts
@@ -229,6 +229,7 @@ export function assertRailParams(
   assert.fieldEquals("Rail", railEntityId, "payer", payer.toHex());
   assert.fieldEquals("Rail", railEntityId, "payee", payee.toHex());
   assert.fieldEquals("Rail", railEntityId, "validator", validator.toHex());
+  assert.fieldEquals("Rail", railEntityId, "arbiter", validator.toHex());
   assert.fieldEquals("Rail", railEntityId, "serviceFeeRecipient", serviceFeeRecipient.toHex());
   assert.fieldEquals("Rail", railEntityId, "commissionRateBps", commissionRateBps.toString());
   assert.fieldEquals("Rail", railEntityId, "totalOneTimePaymentAmount", totalOneTimePaymentAmount);


### PR DESCRIPTION
The old name is outdated.

This is a non-breaking change. Afterwards, update UI, then once shipped, remove the old property from the subgraph.