### PR TITLE
Update top operators sort by USDFC settled descending. Closes #141

### DIFF
--- a/apps/explorer/src/components/Home/TopOperators/components/TopOperatorsTable.tsx
+++ b/apps/explorer/src/components/Home/TopOperators/components/TopOperatorsTable.tsx
@@ -1,11 +1,11 @@
 import { TanstackTable } from "@filecoin-foundation/ui-filecoin/Table/TanstackTable";
 
-import type { Operator } from "@filecoin-pay/types";
+import type { OperatorToken } from "@filecoin-pay/types";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { columns } from "../data/column-definitions";
 
 export type TopOperatorsTableProps = {
-  data: Array<Operator>;
+  data: Array<OperatorToken>;
 };
 
 function TopOperatorsTable({ data }: TopOperatorsTableProps) {

--- a/apps/explorer/src/components/Home/TopOperators/data/column-definitions.tsx
+++ b/apps/explorer/src/components/Home/TopOperators/data/column-definitions.tsx
@@ -1,11 +1,11 @@
-import type { Operator } from "@filecoin-pay/types";
+import type { OperatorToken } from "@filecoin-pay/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@filecoin-pay/ui/components/tooltip";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Info } from "lucide-react";
 import { ExplorerLink } from "@/components/shared";
-import { formatCompactNumber } from "@/utils/formatter";
+import { formatCompactNumber, formatToken } from "@/utils/formatter";
 
-const columnHelper = createColumnHelper<Operator>();
+const columnHelper = createColumnHelper<OperatorToken>();
 
 export const columns = [
   columnHelper.display({
@@ -14,21 +14,35 @@ export const columns = [
     cell: (info) => <span className='font-semibold text-muted-foreground'>{info.row.index + 1}</span>,
     size: 48,
   }),
-  columnHelper.accessor("address", {
+  columnHelper.accessor("operator.address", {
     header: "Address",
     cell: (info) => {
       return <ExplorerLink address={info.getValue()} label='Service address' />;
     },
   }),
-  columnHelper.accessor("totalRails", {
+  columnHelper.accessor(
+    (row) => ({
+      settledAmount: row.settledAmount,
+      token: row.token,
+    }),
+    {
+      id: "usdfcSettled",
+      header: "USDFC settled",
+      cell: (info) => {
+        const { settledAmount, token } = info.getValue();
+        return formatToken(settledAmount, token.decimals, token.symbol, 8);
+      },
+    },
+  ),
+  columnHelper.accessor("operator.totalRails", {
     header: "Total Rails",
     cell: (info) => formatCompactNumber(info.getValue()),
   }),
-  columnHelper.accessor("totalTokens", {
+  columnHelper.accessor("operator.totalTokens", {
     header: "Total Tokens",
     cell: (info) => formatCompactNumber(info.getValue()),
   }),
-  columnHelper.accessor("totalApprovals", {
+  columnHelper.accessor("operator.totalApprovals", {
     header: () => (
       <div className='flex items-center gap-1.5'>
         Total Approvals

--- a/apps/explorer/src/components/Home/TopOperators/index.tsx
+++ b/apps/explorer/src/components/Home/TopOperators/index.tsx
@@ -7,11 +7,15 @@ import { PageSection } from "@filecoin-foundation/ui-filecoin/PageSection";
 import { RefreshOverlay } from "@filecoin-foundation/ui-filecoin/RefreshOverlay";
 import { AlertCircle, SearchIcon } from "lucide-react";
 import { StyledLink } from "@/components/shared";
+import useNetwork from "@/hooks/useNetwork";
 import useOperatorsLeaderboard from "@/hooks/useOperatorsLeaderboard";
 import TopOperatorsTable from "./components/TopOperatorsTable";
 
 const TopOperators = () => {
-  const { data, isLoading, isError, error, isRefetching, refetch } = useOperatorsLeaderboard(10, "totalRails");
+  const { network } = useNetwork();
+  const token =
+    network === "mainnet" ? "0x80B98d3aa09ffff255c3ba4A241111Ff1262F045" : "0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0";
+  const { data, isLoading, isError, error, isRefetching, refetch } = useOperatorsLeaderboard(token);
 
   return (
     <PageSection backgroundVariant='light'>

--- a/apps/explorer/src/components/Home/TopOperators/index.tsx
+++ b/apps/explorer/src/components/Home/TopOperators/index.tsx
@@ -7,14 +7,14 @@ import { PageSection } from "@filecoin-foundation/ui-filecoin/PageSection";
 import { RefreshOverlay } from "@filecoin-foundation/ui-filecoin/RefreshOverlay";
 import { AlertCircle, SearchIcon } from "lucide-react";
 import { StyledLink } from "@/components/shared";
+import { calibration, mainnet } from "@/constants/chains";
 import useNetwork from "@/hooks/useNetwork";
 import useOperatorsLeaderboard from "@/hooks/useOperatorsLeaderboard";
 import TopOperatorsTable from "./components/TopOperatorsTable";
 
 const TopOperators = () => {
   const { network } = useNetwork();
-  const token =
-    network === "mainnet" ? "0x80B98d3aa09ffff255c3ba4A241111Ff1262F045" : "0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0";
+  const token = network === "mainnet" ? mainnet.contracts.usdfc.address : calibration.contracts.usdfc.address;
   const { data, isLoading, isError, error, isRefetching, refetch } = useOperatorsLeaderboard(10, token);
 
   return (

--- a/apps/explorer/src/components/Home/TopOperators/index.tsx
+++ b/apps/explorer/src/components/Home/TopOperators/index.tsx
@@ -15,7 +15,7 @@ const TopOperators = () => {
   const { network } = useNetwork();
   const token =
     network === "mainnet" ? "0x80B98d3aa09ffff255c3ba4A241111Ff1262F045" : "0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0";
-  const { data, isLoading, isError, error, isRefetching, refetch } = useOperatorsLeaderboard(token);
+  const { data, isLoading, isError, error, isRefetching, refetch } = useOperatorsLeaderboard(10, token);
 
   return (
     <PageSection backgroundVariant='light'>

--- a/apps/explorer/src/hooks/useOperatorsLeaderboard.ts
+++ b/apps/explorer/src/hooks/useOperatorsLeaderboard.ts
@@ -1,19 +1,17 @@
-import type { Operator } from "@filecoin-pay/types";
+import type { OperatorToken } from "@filecoin-pay/types";
 import { GET_OPERATORS_LEADERBOARD } from "@/services/grapql/queries";
 import { useGraphQLQuery } from "./useGraphQLQuery";
 
 interface OperatorsLeaderboardResponse {
-  operators: Operator[];
+  operatorTokens: OperatorToken[];
 }
 
-export type OperatorOrderBy = "totalRails" | "totalTokens" | "totalApprovals";
-
-const useOperatorsLeaderboard = (first: number = 10, orderBy: OperatorOrderBy = "totalRails") =>
-  useGraphQLQuery<OperatorsLeaderboardResponse, Operator[]>({
-    queryKey: ["operatorsLeaderboard", first, orderBy],
+const useOperatorsLeaderboard = (token: string) =>
+  useGraphQLQuery<OperatorsLeaderboardResponse, OperatorToken[]>({
+    queryKey: ["operatorsLeaderboard", token],
     query: GET_OPERATORS_LEADERBOARD,
-    variables: { first, orderBy },
-    select: (data) => data.operators,
+    variables: { token },
+    select: (data) => data.operatorTokens,
     refetchInterval: 60 * 1000,
   });
 

--- a/apps/explorer/src/hooks/useOperatorsLeaderboard.ts
+++ b/apps/explorer/src/hooks/useOperatorsLeaderboard.ts
@@ -6,11 +6,11 @@ interface OperatorsLeaderboardResponse {
   operatorTokens: OperatorToken[];
 }
 
-const useOperatorsLeaderboard = (token: string) =>
+const useOperatorsLeaderboard = (first: number = 10, token: string) =>
   useGraphQLQuery<OperatorsLeaderboardResponse, OperatorToken[]>({
-    queryKey: ["operatorsLeaderboard", token],
+    queryKey: ["operatorsLeaderboard", first, token],
     query: GET_OPERATORS_LEADERBOARD,
-    variables: { token },
+    variables: { first, token },
     select: (data) => data.operatorTokens,
     refetchInterval: 60 * 1000,
   });

--- a/apps/explorer/src/services/grapql/queries.ts
+++ b/apps/explorer/src/services/grapql/queries.ts
@@ -57,13 +57,24 @@ export const GET_RECENT_OPERATORS = gql`
 `;
 
 export const GET_OPERATORS_LEADERBOARD = gql`
-  query GetOperatorsLeaderboard($first: Int = 10, $orderBy: Operator_orderBy = totalRails) {
-    operators(first: $first, orderBy: $orderBy, orderDirection: desc) {
-      id
-      address
-      totalRails
-      totalTokens
-      totalApprovals
+  query GetOperatorsByUSDFCSettledAmount($token: String) {
+    operatorTokens(
+      orderBy: settledAmount
+      where: {token: $token}
+      orderDirection: desc
+    ) {
+      settledAmount
+      operator {
+        id
+        address
+        totalRails
+        totalTokens
+        totalApprovals
+      }
+      token {
+        decimals
+        symbol
+      }
     }
   }
 `;

--- a/apps/explorer/src/services/grapql/queries.ts
+++ b/apps/explorer/src/services/grapql/queries.ts
@@ -57,8 +57,9 @@ export const GET_RECENT_OPERATORS = gql`
 `;
 
 export const GET_OPERATORS_LEADERBOARD = gql`
-  query GetOperatorsByUSDFCSettledAmount($token: String) {
+  query GetOperatorsByUSDFCSettledAmount($first: Int = 10, $token: String) {
     operatorTokens(
+      first: $first
       orderBy: settledAmount
       where: {token: $token}
       orderDirection: desc


### PR DESCRIPTION
Sort the services leaderboard by USDFC settled descending:

<img width="1213" height="316" alt="Screenshot 2026-05-04 at 15 22 36" src="https://github.com/user-attachments/assets/8c30ed38-6e57-4531-aee5-259625efc5b4" />

Small downside of the chosen approach: Services without USDFC settlements have disappeared from the table. But, that should be fine for the leaderboard, and they are still visible on the all services pages.

Closes #141