### PR TITLE
feat(Home.Stats): Add metric "# accounts". Closes #65

### DIFF
--- a/apps/explorer/src/components/Home/Stats.tsx
+++ b/apps/explorer/src/components/Home/Stats.tsx
@@ -5,7 +5,14 @@ import { EmptyStateCard } from "@filecoin-foundation/ui-filecoin/EmptyStateCard"
 import { LoadingStateCard } from "@filecoin-foundation/ui-filecoin/LoadingStateCard";
 import { PageSection } from "@filecoin-foundation/ui-filecoin/PageSection";
 import type { IconProps } from "@phosphor-icons/react";
-import { ArrowsSplitIcon, CoinsIcon, LockIcon, UsersIcon } from "@phosphor-icons/react";
+import {
+  ArrowCircleDownLeftIcon,
+  ArrowCircleUpRightIcon,
+  ArrowsSplitIcon,
+  CoinsIcon,
+  LockIcon,
+  UsersIcon,
+} from "@phosphor-icons/react";
 import { AlertCircle } from "lucide-react";
 import { useMemo } from "react";
 import { useBlockNumber } from "@/hooks/useBlockNumber";
@@ -80,6 +87,18 @@ const Stats: React.FC = () => {
         title: "Accounts",
         value: data?.paymentsMetrics?.totalAccounts?.toString() ?? "0",
         icon: UsersIcon,
+        href: `/${network}/accounts`,
+      },
+      {
+        title: "Payees",
+        value: data?.paymentsMetrics?.uniquePayees?.toString() ?? "0",
+        icon: ArrowCircleUpRightIcon,
+        href: `/${network}/accounts`,
+      },
+      {
+        title: "Payers",
+        value: data?.paymentsMetrics?.uniquePayers?.toString() ?? "0",
+        icon: ArrowCircleDownLeftIcon,
         href: `/${network}/accounts`,
       },
       ...(data?.tokens.map((token) => ({

--- a/apps/explorer/src/components/Home/Stats.tsx
+++ b/apps/explorer/src/components/Home/Stats.tsx
@@ -5,7 +5,7 @@ import { EmptyStateCard } from "@filecoin-foundation/ui-filecoin/EmptyStateCard"
 import { LoadingStateCard } from "@filecoin-foundation/ui-filecoin/LoadingStateCard";
 import { PageSection } from "@filecoin-foundation/ui-filecoin/PageSection";
 import type { IconProps } from "@phosphor-icons/react";
-import { ArrowsSplitIcon, CoinsIcon, LockIcon } from "@phosphor-icons/react";
+import { ArrowsSplitIcon, CoinsIcon, LockIcon, UsersIcon } from "@phosphor-icons/react";
 import { AlertCircle } from "lucide-react";
 import { useMemo } from "react";
 import { useBlockNumber } from "@/hooks/useBlockNumber";
@@ -75,6 +75,12 @@ const Stats: React.FC = () => {
         value: data?.paymentsMetrics?.totalActiveRails?.toString() ?? "0",
         icon: ArrowsSplitIcon,
         href: `/${network}/rails`,
+      },
+      {
+        title: "Accounts",
+        value: data?.paymentsMetrics?.totalAccounts?.toString() ?? "0",
+        icon: UsersIcon,
+        href: `/${network}/accounts`,
       },
       ...(data?.tokens.map((token) => ({
         title: `Total ${token.symbol} Transacted`,


### PR DESCRIPTION
<img width="344" height="181" alt="Screenshot 2026-05-05 at 16 23 40" src="https://github.com/user-attachments/assets/71938380-cba0-4b55-8b3c-fdaed1a63305" />

As discussed with @jennijuju, for GA, total wallet addresses seen is enough to show.

Closes #65