### PR TITLE
ops: add release issue template and deployment docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -8,7 +8,10 @@ assignees: ""
 
 ## Release Checklist
 
-> **Subgraphs dashboard:** https://app.goldsky.com/project_cmb9tuo8r1xdw01ykb8uidk7h/dashboard/subgraphs
+### Notes
+* **Goldsky Subgraphs dashboard:** https://app.goldsky.com/project_cmb9tuo8r1xdw01ykb8uidk7h/dashboard/subgraphs
+* This process is for deploying new subgraph versions. Static site changes are automatically deployed as part of the [Vercel GitHub App configuration.](https://github.com/organizations/FilOzone/settings/installations/85630569)
+* This release process assumes that the static site and subgraph are decoupled. Additional steps need to be taken to make a breaking subgraph change that requires a static site change.
 
 ### 1. Define the new version
 
@@ -52,7 +55,8 @@ NEXT_PUBLIC_SUBGRAPH_URL_CALIBRATION=https://api.goldsky.com/api/public/project_
 
 ### 6. Promote subgraphs to `prod`
 
-Tagging as `prod` causes [pay.filecoin.cloud](https://pay.filecoin.cloud) to switch over to the new version.
+> [!NOTE]                                                                                    
+> Tagging as `prod` below causes [pay.filecoin.cloud](https://pay.filecoin.cloud) to switch over to the new version. Do this when you're ready to update the production site.
 
 ```bash
 for network in mainnet calibration; do
@@ -70,7 +74,7 @@ done
 
 - [ ] [pay.filecoin.cloud](https://pay.filecoin.cloud) loads and functions correctly after the tag switch
 
-### 8. Wraup
+### 8. Wrapup
 
 - [ ] Announce the release in #fil-foc
 - [ ] Document if there any improvements that need to be made to the release process

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,77 @@
+---
+name: Release
+about: Checklist for publishing a new release
+title: "Release vX.Y.Z"
+labels: release
+assignees: ""
+---
+
+## Release Checklist
+
+> **Subgraphs dashboard:** https://app.goldsky.com/project_cmb9tuo8r1xdw01ykb8uidk7h/dashboard/subgraphs
+
+### 1. Define the new version
+
+```bash
+NEW_RELEASE_VERSION="vX.Y.Z"
+```
+
+- [ ] Version string agreed and set
+
+### 2. Create a GitHub release
+
+```bash
+gh release create "$NEW_RELEASE_VERSION" \
+  --title "$NEW_RELEASE_VERSION" \
+  --generate-notes
+```
+
+- [ ] GitHub release created with tag `vX.Y.Z`
+
+### 3. Build and publish the subgraph
+
+- [ ] **Automated:** confirm that the [`deploy` workflow](../../actions/workflows/deploy.yml) triggered on the new tag and completed successfully
+- [ ] **Manual fallback:** if the workflow did not run, follow the [manual deployment steps](../../packages/subgraph/README.md#manually-deploying-the-subgraph-to-goldsky)
+
+### 4. Await subgraph indexing
+
+- [ ] Received confirmation email that `filecoin-pay-mainnet` has finished indexing
+- [ ] Received confirmation email that `filecoin-pay-calibration` has finished indexing
+
+### 5. Verify the Explorer against the new subgraph version
+
+Set the following environment variables locally and smoke-test the Explorer:
+
+```bash
+NEXT_PUBLIC_SUBGRAPH_URL_MAINNET=https://api.goldsky.com/api/public/project_cmb9tuo8r1xdw01ykb8uidk7h/subgraphs/filecoin-pay-mainnet/$NEW_RELEASE_VERSION/gn
+NEXT_PUBLIC_SUBGRAPH_URL_CALIBRATION=https://api.goldsky.com/api/public/project_cmb9tuo8r1xdw01ykb8uidk7h/subgraphs/filecoin-pay-calibration/$NEW_RELEASE_VERSION/gn
+```
+
+- [ ] Explorer loads without errors on mainnet
+- [ ] Explorer loads without errors on calibration
+
+### 6. Promote subgraphs to `prod`
+
+Tagging as `prod` causes [pay.filecoin.cloud](https://pay.filecoin.cloud) to switch over to the new version.
+
+```bash
+for network in mainnet calibration; do
+  # Remove the prod tag from the previous version (if present)
+  goldsky subgraph tag delete filecoin-pay-$network/prod --tag prod 2>/dev/null || true
+  # Apply prod tag to the new version
+  goldsky subgraph tag create filecoin-pay-$network/$NEW_RELEASE_VERSION --tag prod
+done
+```
+
+- [ ] `filecoin-pay-mainnet` tagged as `prod`
+- [ ] `filecoin-pay-calibration` tagged as `prod`
+
+### 7. Verify production
+
+- [ ] [pay.filecoin.cloud](https://pay.filecoin.cloud) loads and functions correctly after the tag switch
+
+### 8. Wraup
+
+- [ ] Announce the release in #fil-foc
+- [ ] Document if there any improvements that need to be made to the release process
+- Close this issue

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -3,7 +3,6 @@ name: Release
 about: Checklist for publishing a new release
 title: "Release vX.Y.Z"
 labels: release
-assignees: ""
 ---
 
 ## Release Checklist
@@ -16,16 +15,17 @@ assignees: ""
 ### 1. Define the new version
 
 ```bash
-NEW_RELEASE_VERSION="vX.Y.Z"
+NEW_RELEASE_VERSION="X.Y.Z"   # no v prefix — used for Goldsky subgraph names
+CURRENT_VERSION="X.Y.Z"       # version currently tagged as prod (will be replaced)
 ```
 
-- [ ] Version string agreed and set
+- [ ] Version strings agreed and set
 
 ### 2. Create a GitHub release
 
 ```bash
-gh release create "$NEW_RELEASE_VERSION" \
-  --title "$NEW_RELEASE_VERSION" \
+gh release create "v$NEW_RELEASE_VERSION" \
+  --title "v$NEW_RELEASE_VERSION" \
   --generate-notes
 ```
 
@@ -61,7 +61,7 @@ NEXT_PUBLIC_SUBGRAPH_URL_CALIBRATION=https://api.goldsky.com/api/public/project_
 ```bash
 for network in mainnet calibration; do
   # Remove the prod tag from the previous version (if present)
-  goldsky subgraph tag delete filecoin-pay-$network/prod --tag prod 2>/dev/null || true
+  goldsky subgraph tag delete filecoin-pay-$network/$CURRENT_VERSION --tag prod 2>/dev/null || true
   # Apply prod tag to the new version
   goldsky subgraph tag create filecoin-pay-$network/$NEW_RELEASE_VERSION --tag prod
 done
@@ -77,5 +77,5 @@ done
 ### 8. Wrapup
 
 - [ ] Announce the release in #fil-foc
-- [ ] Document if there any improvements that need to be made to the release process
-- Close this issue
+- [ ] Document if there are any improvements that need to be made to the release process
+- [ ] Close this issue

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ cd ../..
 - **Test:** `pnpm test`
 - **Clean:** `pnpm clean` (removes build artifacts and node_modules)
 
+## Releasing
+
+To publish a new release, open a GitHub issue using the [Release template](.github/ISSUE_TEMPLATE/release.md). It walks through every step: creating the GitHub release, verifying the subgraph deployment, and promoting to production.
+
 ## Contributing
 
 - Use Node/pnpm versions from root `package.json` engines.

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -2,11 +2,13 @@
 
 This guide details the steps required to deploy the provided subgraph to supported subgraph hosting platforms (e.g., Goldsky, Protofire etc.).
 
+For a full end-to-end release walkthrough, use the [release issue template](../../.github/ISSUE_TEMPLATE/release.md).
+
 ## CI/CD
 
-Create a GitHub release with a tag `vX.Y.Z` when you wish to deploy a new version of the subgraph. GitHub Actions will build and publish the subgraph.
+A GitHub release with a tag will deploy new subraph versions per [deploy.yml](../../.github/workflows/deploy.yml).
 
-Once you have received confirmation emails that the mainnet and calibration subgraphs have finished indexing, tag the new subgraphs with `prod`.
+CI/CD doesn't currently do any validation or subgraph tagging. 
 
 ## Prerequisites
 

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -6,7 +6,7 @@ For a full end-to-end release walkthrough, use the [release issue template](../.
 
 ## CI/CD
 
-A GitHub release with a tag will deploy new subraph versions per [deploy.yml](../../.github/workflows/deploy.yml).
+A GitHub release with a tag matching `vX.Y.Z` will deploy new subgraph versions per [deploy.yml](../../.github/workflows/deploy.yml).
 
 CI/CD doesn't currently do any validation or subgraph tagging. 
 


### PR DESCRIPTION
- Adds `.github/ISSUE_TEMPLATE/release.md` — a release checklis
- Adds pointers to the release process in the various readmes.

This is coming out of discussion in https://github.com/FilOzone/filecoin-pay-explorer/issues/49