### PR TITLE
fix: null token in OperatorToken

### DIFF
--- a/packages/subgraph/src/payments.ts
+++ b/packages/subgraph/src/payments.ts
@@ -71,7 +71,9 @@ export function handleOperatorApprovalUpdated(event: OperatorApprovalUpdatedEven
   const lockupAllowance = event.params.lockupAllowance;
   const maxLockupPeriod = event.params.maxLockupPeriod;
 
-  const isNewToken = getTokenDetails(tokenAddress).isNew;
+  const tokenDetails = getTokenDetails(tokenAddress);
+  const isNewToken = tokenDetails.isNew;
+  if (isNewToken) tokenDetails.token.save();
 
   const clientAccount = Account.load(clientAddress);
 
@@ -534,7 +536,7 @@ export function handleDepositRecorded(event: DepositRecordedEvent): void {
   const tokenWithIsNew = getTokenDetails(tokenAddress);
   const token = tokenWithIsNew.token;
   const isNewToken = tokenWithIsNew.isNew;
-  const isFirstDeposit = isNewToken || token.userFunds.equals(ZERO_BIG_INT);
+  const isFirstDeposit = isNewToken || token.totalDeposits.equals(ZERO_BIG_INT);
 
   // Ensure the Account exists before the UserToken
   const isNewAccount = createOrLoadAccountByAddress(accountAddress).isNew;

--- a/packages/subgraph/src/payments.ts
+++ b/packages/subgraph/src/payments.ts
@@ -71,6 +71,8 @@ export function handleOperatorApprovalUpdated(event: OperatorApprovalUpdatedEven
   const lockupAllowance = event.params.lockupAllowance;
   const maxLockupPeriod = event.params.maxLockupPeriod;
 
+  const isNewToken = getTokenDetails(tokenAddress).isNew;
+
   const clientAccount = Account.load(clientAddress);
 
   let isNewApproval = false;
@@ -122,6 +124,7 @@ export function handleOperatorApprovalUpdated(event: OperatorApprovalUpdatedEven
     operatorAddress,
     isNewApproval,
     isNewOperator,
+    isNewToken,
     event.block.timestamp,
     event.block.number,
   );
@@ -531,6 +534,7 @@ export function handleDepositRecorded(event: DepositRecordedEvent): void {
   const tokenWithIsNew = getTokenDetails(tokenAddress);
   const token = tokenWithIsNew.token;
   const isNewToken = tokenWithIsNew.isNew;
+  const isFirstDeposit = isNewToken || token.userFunds.equals(ZERO_BIG_INT);
 
   // Ensure the Account exists before the UserToken
   const isNewAccount = createOrLoadAccountByAddress(accountAddress).isNew;
@@ -549,7 +553,7 @@ export function handleDepositRecorded(event: DepositRecordedEvent): void {
   userToken.save();
 
   // Native FIL has no ERC-20 contract, so no Transfer events to track.
-  if (isNewToken && !isNativeToken(tokenAddress)) {
+  if (isFirstDeposit && !isNativeToken(tokenAddress)) {
     const paymentsAddress = event.address;
     const context = new DataSourceContext();
     context.setBytes("paymentsAddress", paymentsAddress);

--- a/packages/subgraph/src/utils/metrics/collectors.ts
+++ b/packages/subgraph/src/utils/metrics/collectors.ts
@@ -357,11 +357,13 @@ export class OperatorApprovalCollector extends BaseMetricsCollector {
   private operatorAddress: Address;
   private isNewApproval: boolean;
   private isNewOperator: boolean;
+  private isNewToken: boolean;
 
   constructor(
     operatorAddress: Address,
     isNewApproval: boolean,
     isNewOperator: boolean,
+    isNewToken: boolean,
     timestamp: GraphBN,
     blockNumber: GraphBN,
   ) {
@@ -369,6 +371,7 @@ export class OperatorApprovalCollector extends BaseMetricsCollector {
     this.operatorAddress = operatorAddress;
     this.isNewApproval = isNewApproval;
     this.isNewOperator = isNewOperator;
+    this.isNewToken = isNewToken;
   }
 
   collect(): void {
@@ -386,11 +389,15 @@ export class OperatorApprovalCollector extends BaseMetricsCollector {
   }
 
   private updateNetworkMetrics(): void {
+    const networkMetric = MetricsEntityManager.loadOrCreatePaymentsMetric();
     if (this.isNewOperator) {
-      const networkMetric = MetricsEntityManager.loadOrCreatePaymentsMetric();
       networkMetric.totalOperators = networkMetric.totalOperators.plus(ONE_BIG_INT);
-      networkMetric.save();
     }
+
+    if (this.isNewToken) {
+      networkMetric.totalTokens = networkMetric.totalTokens.plus(ONE_BIG_INT);
+    }
+    networkMetric.save();
   }
 }
 
@@ -564,6 +571,7 @@ export class MetricsCollectionOrchestrator {
     operatorAddress: Address,
     isNewApproval: boolean,
     isNewOperator: boolean,
+    isNewToken: boolean,
     timestamp: GraphBN,
     blockNumber: GraphBN,
   ): void {
@@ -571,6 +579,7 @@ export class MetricsCollectionOrchestrator {
       operatorAddress,
       isNewApproval,
       isNewOperator,
+      isNewToken,
       timestamp,
       blockNumber,
     );


### PR DESCRIPTION
OperatorTokens resolve null values for `token`, resulting in complete query failure for `OperatorTokens` if `token` field is requested.

Query -
```
query GetOperatorTokensWithTokenName {
  operatorTokens {
    token {
      name
    }
  }
}
```

Error -  
```
{
  "errors": [
    {
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "message": "Null value resolved for non-null field `token`"
    }
  ]
}
```