### PR TITLE
fix(explorer): pass synapse asChain validation when wallet connected

### DIFF
--- a/apps/explorer/src/app/error.tsx
+++ b/apps/explorer/src/app/error.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@filecoin-foundation/ui-filecoin/Button";
+import { ErrorStateCard } from "@filecoin-foundation/ui-filecoin/ErrorStateCard";
+import { WarningCircleIcon } from "@phosphor-icons/react";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorBoundary({ error, reset }: ErrorProps) {
+  return (
+    <ErrorStateCard
+      titleTag='h1'
+      IconComponent={WarningCircleIcon}
+      title='Something went wrong'
+      description={error.message || "An unexpected error occurred. Please try again."}
+    >
+      <Button variant='primary' onClick={reset}>
+        Try again
+      </Button>
+    </ErrorStateCard>
+  );
+}

--- a/apps/explorer/src/app/error.tsx
+++ b/apps/explorer/src/app/error.tsx
@@ -10,12 +10,21 @@ type ErrorProps = {
 };
 
 export default function ErrorBoundary({ error, reset }: ErrorProps) {
+  // Avoid leaking internal error details to end users in production; the raw
+  // message is only useful during development.
+  const description =
+    process.env.NODE_ENV === "development"
+      ? error.message || "An unexpected error occurred. Please try again."
+      : error.digest
+        ? `An unexpected error occurred. Please try again. Reference: ${error.digest}`
+        : "An unexpected error occurred. Please try again.";
+
   return (
     <ErrorStateCard
       titleTag='h1'
       IconComponent={WarningCircleIcon}
       title='Something went wrong'
-      description={error.message || "An unexpected error occurred. Please try again."}
+      description={description}
     >
       <Button variant='primary' onClick={reset}>
         Try again

--- a/apps/explorer/src/constants/chains.ts
+++ b/apps/explorer/src/constants/chains.ts
@@ -1,47 +1,30 @@
 import { calibration as synapseCalibration, mainnet as synapseMainnet } from "@filoz/synapse-sdk";
-import type { Chain as ViemChain } from "viem";
 
 import type { Network } from "@/types";
 
-export type Contract = {
-  implementation: string;
-  proxy: string;
-};
-
-export type WarmStorage = {
-  implementation: string;
-  proxy: string;
-  stateView: string;
-};
-
-export type Contracts = {
-  pdp?: Partial<Contract>;
-  warmStorage: WarmStorage;
-  serviceProviderRegistry: Contract;
-};
+type SynapseChain = typeof synapseMainnet;
 
 /**
- * Viem compatible chain interface with WarmStorage and ServiceRegistry contracts
+ * Synapse chain augmented with explorer display fields and a `payments`
+ * alias for the `filecoinPay` contract.
+ *
+ * The full synapse contract set (`filecoinPay`, `fwss`, …) and
+ * `genesisTimestamp` are preserved so that the chain object carried by the
+ * wagmi connector client passes `@filoz/synapse-core`'s `asChain` validation
+ * when a wallet (e.g. MetaMask) is connected.
  */
-export interface Chain extends ViemChain {
+export interface Chain extends SynapseChain {
   label: string;
   slug: Network;
-  contracts: {
-    payments: typeof synapseMainnet.contracts.filecoinPay;
-    usdfc: typeof synapseMainnet.contracts.usdfc;
+  contracts: SynapseChain["contracts"] & {
+    payments: SynapseChain["contracts"]["filecoinPay"];
   };
 }
 
 export const mainnet: Chain = {
-  id: 314,
+  ...synapseMainnet,
   label: "Mainnet",
   slug: "mainnet",
-  name: "Filecoin - Mainnet",
-  nativeCurrency: {
-    name: "Filecoin",
-    symbol: "FIL",
-    decimals: 18,
-  },
   rpcUrls: {
     default: {
       http: ["https://api.node.glif.io/rpc/v1"],
@@ -67,21 +50,15 @@ export const mainnet: Chain = {
     },
   },
   contracts: {
+    ...synapseMainnet.contracts,
     payments: synapseMainnet.contracts.filecoinPay,
-    usdfc: synapseMainnet.contracts.usdfc,
   },
 };
 
 export const calibration: Chain = {
-  id: 314_159,
+  ...synapseCalibration,
   label: "Calibration",
   slug: "calibration",
-  name: "Filecoin - Calibration testnet",
-  nativeCurrency: {
-    name: "Filecoin",
-    symbol: "tFIL",
-    decimals: 18,
-  },
   rpcUrls: {
     default: {
       http: ["https://api.calibration.node.glif.io/rpc/v1"],
@@ -107,8 +84,8 @@ export const calibration: Chain = {
     },
   },
   contracts: {
+    ...synapseCalibration.contracts,
     payments: synapseCalibration.contracts.filecoinPay,
-    usdfc: synapseCalibration.contracts.usdfc,
   },
 };
 

--- a/apps/explorer/src/services/wagmi/config.tsx
+++ b/apps/explorer/src/services/wagmi/config.tsx
@@ -6,6 +6,7 @@ export const supportedChains = [mainnet, calibration] as const;
 
 export const config = createConfig({
   chains: supportedChains,
+  ssr: true,
   transports: {
     [calibration.id]: http(),
     [mainnet.id]: http(),


### PR DESCRIPTION
```
Application error: a client-side exception has occurred while loading pay.filecoin.cloud (see the browser console for more information).
```
```
Uncaught Error: Minified React error #418; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at rT (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:43323)
    at oV (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:92647)
    at iy (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:122763)
    at a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:118811
    at il (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:118912)
    at iq (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:141009)
    at MessagePort.T (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:6434)了解此错误
6343454f0aacabe5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1 Uncaught UnsupportedChainError: Unsupported chain: 314159 (only Filecoin mainnet (314), calibration (314159), and devnet (31415926) are supported). Import chains from @filoz/synapse-core/chains to get the correct chain.
    at tu (6343454f0aacabe5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:282414)
    at tc (6343454f0aacabe5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:282449)
    at 305f9cde82171e9a.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:502590
    at oZ (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:97038)
    at uw (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112930)
    at uk (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112814)
    at uw (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112975)
    at uk (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112814)
    at uw (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112975)
    at uk (a6d955bebddf7ca5.js?dpl=dpl_6YaarBQ2t8PeMG2iwJ8rmEYFJTnW:1:112814)
```
<img width="1795" height="1280" alt="image" src="https://github.com/user-attachments/assets/d57a8d6f-0ace-4e71-ab26-938dd3e26b86" />
