### PR TITLE
chore(explorer): next-16 code migration

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "biome check --write",
     "format": "biome format --write"

--- a/apps/explorer/src/proxy.ts
+++ b/apps/explorer/src/proxy.ts
@@ -5,7 +5,7 @@ import { DEFAULT_NETWORK } from "@/utils/constants";
 
 const VALID_NETWORKS: readonly string[] = supportedChains.map((chain) => chain.slug);
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (pathname === "/") {

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -25,6 +25,6 @@
       "@/styles/*": ["./src/styles/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
PR #228 only bumped the `next` dependency to `16.2.6`; the app code still used Next 15 conventions. This PR drives the actual app migration.